### PR TITLE
test: Clean up homebrew setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,12 +33,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - uses: actions/setup-go@v4
+        uses: Homebrew/actions/setup-homebrew@main
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
       - run: |
-          brew install bats-core coreutils gnu-getopt jq xq yq
+          brew tap bats-core/bats-core
+          brew install bats-core gnu-getopt jq xq yq
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:


### PR DESCRIPTION
## The Issue

Some homebrew stuff started failing, https://github.com/ddev/signing_tools/actions/runs/15917434690/job/44897549221

```
==> Installing bats-core
==> Pouring bats-core--1.12.0.all.bottle.tar.gz
🍺  /usr/local/Cellar/bats-core/1.12.0: 28 files, 168.5KB
==> Downloading https://ghcr.io/v2/homebrew/core/coreutils/manifests/9.7
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/42f4c2e61aba25d3ead49fbfc09e225ee50c3adbc35e4b6ce7a72d4ebe4a[34](https://github.com/ddev/signing_tools/actions/runs/15917434690/job/44897549221#step:5:35)60--coreutils-9.7.bottle_manifest.json
Error: Formula installation already attempted: coreutils
```

## How This PR Solves The Issue

Update, don't double-install coreutils


<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

